### PR TITLE
Changes publishing branch to master, only use prod for tracking

### DIFF
--- a/.github/workflows/sync_with_oss.yaml
+++ b/.github/workflows/sync_with_oss.yaml
@@ -17,7 +17,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.PAT }}
-          ref: prod
           fetch-depth: 0
 
       # Create publish workflow for every commit that is picked up
@@ -34,17 +33,8 @@ jobs:
               echo $commit
               git rebase $commit
               git push origin prod
+              git checkout master
+              git cherry-pick $commit
+              git push origin master
+              git checkout prod
           done
-
-      - uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.PAT }}
-          ref: master
-          fetch-depth: 0
-
-      - name: Update master to upstream for tracking
-        run: |
-          git config --global user.email "wlo@linkedin.com"
-          git config --global user.name "William Lo"
-          git pull upstream master
-          git push origin master

--- a/.github/workflows/test_and_deploy.yaml
+++ b/.github/workflows/test_and_deploy.yaml
@@ -21,7 +21,7 @@ on:
   push:
     # Publish only on `prod`
     branches:
-      - prod
+      - master
   release:
     types: [published, edited]
 


### PR DESCRIPTION
Previous pipeline attempted to push from prod, but prod needs to include github action files in order to be kicked off properly.
Instead, only use branch `prod` to track SHAs and changes from upstream OSS. Then, cherry-pick the commits onto master and push, kicking off a pipeline for each commit on master. 