### PR TITLE
Fix 'occured' -> 'occurred' typos in Issue.pdl and HiveOrcSerDeManager

### DIFF
--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/orc/HiveOrcSerDeManager.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/orc/HiveOrcSerDeManager.java
@@ -249,7 +249,7 @@ public class HiveOrcSerDeManager extends HiveSerDeManager {
 
       return true;
     } catch (Exception e) {
-      throw new RuntimeException("Error occured when checking the type of file:" + file);
+      throw new RuntimeException("Error occurred when checking the type of file:" + file);
     }
   }
 

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/pegasus/org/apache/gobblin/service/Issue.pdl
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/pegasus/org/apache/gobblin/service/Issue.pdl
@@ -8,7 +8,7 @@ namespace org.apache.gobblin.service
 record Issue {
 
   /**
-   * Time when the issue have occured
+   * Time when the issue have occurred
    */
   time: Timestamp
 


### PR DESCRIPTION
Fix 2 instances:

- `gobblin-restli/.../Issue.pdl` line 11: Pegasus schema doc comment
- `gobblin-hive-registration/.../HiveOrcSerDeManager.java` line 252: RuntimeException message

Comment/exception-string change only.